### PR TITLE
Addressing issue of wrongly freeing un- or StatefulSet managed Pod IPs

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b19b35b5750771f3abd55c130501e745ec0d4aafb8c2568e10639eee12053081
-updated: 2020-01-14T16:25:15.669355147+01:00
+hash: 2f67bfbb19441f4b8486e776de36cfb0e96148ac4da404e3e7fcf35e79d7e7b7
+updated: 2020-03-12T13:09:16.371821852+01:00
 imports:
 - name: github.com/apparentlymart/go-cidr
   version: 2bd8b58cf4275aeb086ade613de226773e29e853
@@ -75,7 +75,7 @@ imports:
 - name: github.com/modern-go/reflect2
   version: 05fbef0ca5da472bbf96c9322b84a53edc03c9fd
 - name: github.com/nokia/danm
-  version: 73ef02908ccc87ef831deeb6a206b8b7e3744626
+  version: 2705b5d3c2a19feabcb60ec30a1ea9b291858142
   subpackages:
   - crd/apis/danm
   - crd/apis/danm/v1
@@ -94,6 +94,8 @@ imports:
   - pkg/netcontrol
 - name: github.com/peterbourgon/diskv
   version: 5f041e8faa004a95c88a202771f4cc3e991971e6
+- name: github.com/satori/go.uuid
+  version: 36e9d2ebbde5e3f13ab2e25625fd453271d6522e
 - name: github.com/spf13/pflag
   version: 583c0c0531f06d5278b7d917446061adc344b5cd
 - name: golang.org/x/crypto

--- a/glide.yaml
+++ b/glide.yaml
@@ -30,3 +30,6 @@ import:
   - tools/leaderelection/resourcelock
   - tools/record
   - util/workqueue
+- package: github.com/nokia/danm
+  version: 2705b5d3c2a19feabcb60ec30a1ea9b291858142 
+


### PR DESCRIPTION
Supposed to fix https://github.com/nokia/danm-utils/issues/4
Changing Pod name check to also compare Pod UID when deciding if a Pod belongs to a DanmEp, or not.
This is needed to be able to definitively decide if a DanmEp's Pod exists, or not.
Also added a delay, and a re-check before we free an IP to avod accidentally racing with an ongoing CNI operation.
Lastly, to be inline with recent upstream DANM change DanmEp is not cleared anymore when an IP could not be freed for some reason.
This will result in a retrial during the next periodic tick.