### PR TITLE
DANM micro-segmentation: implement DanmEp filtering algorithm plus creating class structure for the event handlers

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,7 @@ github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.7 h1:VRuXN2EnMSsZdauzdss6JBC29YotDqG59BZ+tdlIL1s=
 github.com/go-openapi/swag v0.19.7/go.mod h1:ao+8BpOPyKdpQz3AOJfbeEVpLmWAvlT1IfTe5McPyhY=
+github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c h1:RBUpb2b14UnmRHNd2uHz20ZHLDK+SW5Us/vWF5IHRaY=
 github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=

--- a/pkg/depset/depset.go
+++ b/pkg/depset/depset.go
@@ -1,0 +1,39 @@
+package depset
+
+import (
+  "log"
+  "context"
+  danmv1 "github.com/nokia/danm/crd/apis/danm/v1"
+  danmclientset "github.com/nokia/danm/crd/client/clientset/versioned"
+  "github.com/nokia/danm-utils/types/poltypes"
+  metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type DanmEpSet struct {
+  DanmEps *poltypes.DanmEpBuckets
+}
+
+func NewDanmEpSet(danmClient danmclientset.Interface, namespace string) *DanmEpSet {
+  var depSet DanmEpSet
+  deps, err := danmClient.DanmV1().DanmEps(namespace).List(context.TODO(), metav1.ListOptions{})
+  if err != nil {
+    log.Println("ERROR: can't list DANM DanmEps API because:" + err.Error())
+    return &depSet
+  }
+  depSet.DanmEps = sortDepsIntoBuckets(deps.Items)
+  return &depSet
+}
+
+func sortDepsIntoBuckets(deps []danmv1.DanmEp) *poltypes.DanmEpBuckets {
+  depBuckets := make(poltypes.DanmEpBuckets, 0)
+  depUidCache := make(map[string]poltypes.UidCache, 0)
+  for _, dep := range deps {
+    for key, value := range dep.ObjectMeta.Labels {
+      if _, ok := depUidCache[key+value+poltypes.CustomBucketPostfix][dep.ObjectMeta.UID]; !ok {
+        depUidCache[key+value+poltypes.CustomBucketPostfix][dep.ObjectMeta.UID] = true
+        depBuckets[key+value+poltypes.CustomBucketPostfix] = append(depBuckets[key+value+poltypes.CustomBucketPostfix], dep)
+      }
+    }
+  }
+  return &depBuckets
+}

--- a/pkg/netruleset/netruleset.go
+++ b/pkg/netruleset/netruleset.go
@@ -1,0 +1,10 @@
+package netruleset
+
+import (
+  polv1 "github.com/nokia/danm-utils/crd/api/netpol/v1"
+  "github.com/nokia/danm-utils/types/poltypes"
+)
+
+func NewNetRuleSet(polSet []polv1.DanmNetworkPolicy, depSet *poltypes.DanmEpBuckets, namespace string) *poltypes.NetRuleSet {
+  return &poltypes.NetRuleSet{}
+}

--- a/pkg/polset/polset.go
+++ b/pkg/polset/polset.go
@@ -5,14 +5,9 @@ import (
   "context"
   polv1 "github.com/nokia/danm-utils/crd/api/netpol/v1"
   polclientset "github.com/nokia/danm-utils/crd/client/clientset/versioned"
+  "github.com/nokia/danm-utils/types/poltypes"
   corev1 "k8s.io/api/core/v1"
   metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-  "k8s.io/apimachinery/pkg/types"
-)
-
-const (
-  DefaultBucketName   = "default"
-  CustomBucketPostfix = "bucket42"
 )
 
 type PolicySet struct {
@@ -36,16 +31,16 @@ func sortPoliciesIntoBuckets(netPols []polv1.DanmNetworkPolicy) map[string][]pol
   for _, policy := range netPols {
     selectors, err := metav1.LabelSelectorAsMap(&policy.Spec.PodSelector)
     if err != nil {
-      log.Println("WARNING: PodSelector field of DanmNetworkPolicy:" + policy.ObjectMeta.Name + " in namespace:"
-        + policy.ObjectMeta.Namespace + " could not be parsed and is therefore ignored because of error:" + err.Error())
+      log.Println("WARNING: PodSelector field of DanmNetworkPolicy:" + policy.ObjectMeta.Name + " in namespace:" +
+        policy.ObjectMeta.Namespace + " could not be parsed and is therefore ignored because of error:" + err.Error())
       continue
     }
     if len(selectors) == 0 {
       //From K8s documentation: "an empty podSelector selects all pods in the namespace"
-      polBuckets[DefaultBucketName] = append(polBuckets[DefaultBucketName], policy)
+      polBuckets[poltypes.DefaultBucketName] = append(polBuckets[poltypes.DefaultBucketName], policy)
     } else {
       for key, value := range selectors {
-        polBuckets[key+value+CustomBucketPostfix] = append(polBuckets[key+value+CustomBucketPostfix], policy)
+        polBuckets[key+value+poltypes.CustomBucketPostfix] = append(polBuckets[key+value+poltypes.CustomBucketPostfix], policy)
       }
     }
   }
@@ -53,22 +48,22 @@ func sortPoliciesIntoBuckets(netPols []polv1.DanmNetworkPolicy) map[string][]pol
 }
 
 func (polSet *PolicySet) FilterApplicablePolicies(pod *corev1.Pod) []polv1.DanmNetworkPolicy {
-  polUidCache := make(map[types.UID]bool, 0)
+  polUidCache := make(poltypes.UidCache, 0)
   applicablePolicies := make([]polv1.DanmNetworkPolicy, 0)
   for key, value := range pod.ObjectMeta.Labels {
     //there are NetworkPolicies selecting the Pod cause a bucket for this specific label exists
-    if policies, ok := polSet.NetPols[key+value+CustomBucketPostfix]; ok {
+    if policies, ok := polSet.NetPols[key+value+poltypes.CustomBucketPostfix]; ok {
       applicablePolicies, polUidCache = filterPoliciesWithoutDupes(policies, applicablePolicies, polUidCache)
     }
   }
   //Default policies are selecting all Pods in the namespace, so if the default bucket exists we need to treat all pols in it as applicable
-  if policies, ok := polSet.NetPols[DefaultBucketName]; ok {
+  if policies, ok := polSet.NetPols[poltypes.DefaultBucketName]; ok {
     applicablePolicies, polUidCache = filterPoliciesWithoutDupes(policies, applicablePolicies, polUidCache)
   }
   return applicablePolicies
 }
 
-func filterPoliciesWithoutDupes(policies, applicablePolicies []polv1.DanmNetworkPolicy, podUidCache map[types.UID]bool) ([]polv1.DanmNetworkPolicy,map[types.UID]bool){
+func filterPoliciesWithoutDupes(policies, applicablePolicies []polv1.DanmNetworkPolicy, podUidCache poltypes.UidCache) ([]polv1.DanmNetworkPolicy,poltypes.UidCache){
   for _, policy := range policies {
     //the same policy might select the Pod multiple times via different labels
     //we need to weed out the duplicates by not adding them again if they are already in the list

--- a/pkg/provisioner/iptables/iptables.go
+++ b/pkg/provisioner/iptables/iptables.go
@@ -1,0 +1,20 @@
+package iptables
+
+import (
+  "github.com/nokia/danm-utils/types/poltypes"
+  corev1 "k8s.io/api/core/v1"
+  "k8s.io/kubernetes/pkg/util/iptables"
+)
+
+type IptablesProvisioner struct {
+  V4Provisioner iptables.Interface
+  V6Provisioner iptables.Interface
+}
+
+func NewIptablesProvisioner() *IptablesProvisioner {
+  return &IptablesProvisioner{}
+}
+
+func (iptabProv *IptablesProvisioner) AddRulesToPod(ruleSet *poltypes.NetRuleSet, pod *corev1.Pod) error {
+  return nil
+}

--- a/types/poltypes/poltypes.go
+++ b/types/poltypes/poltypes.go
@@ -1,0 +1,41 @@
+package poltypes
+
+import (
+  "net"
+  danmv1 "github.com/nokia/danm/crd/apis/danm/v1"
+  corev1 "k8s.io/api/core/v1"
+  "k8s.io/apimachinery/pkg/types"
+)
+
+const (
+  DefaultBucketName   = "default"
+  CustomBucketPostfix = "bucket42"
+)
+
+type RuleProvisioner interface {
+  AddRulesToPod(*NetRuleSet,*corev1.Pod) error
+}
+
+type UidCache map[types.UID]bool
+
+type DanmEpBuckets map[string][]danmv1.DanmEp
+
+type NetRuleSet struct {
+  IngressV4Chain NetRuleChain
+  IngressV6Chain NetRuleChain
+  EgressV4Chain  NetRuleChain
+  EgressV6Chain  NetRuleChain
+}
+
+type NetRuleChain struct {
+  Name string
+  Rules []NetRule
+}
+
+type NetRule struct {
+  SourceIp   *net.IPNet
+  SourcePort int
+  DestIp     *net.IPNet
+  DestPort   int
+  Protocol   string
+}


### PR DESCRIPTION
The imagined flow is first sorting applicable network policies and DanmEps into appropriate buckets based on their labels, then parsing an applicable set of rules from the two sets.
Finally the the list of rules are passed to a provisioner via an abstract interface.
The first such provisioner will be obviously "iptables", but a future, better performing eBPF based provisioner is also very much in the picture.