### PR TITLE
DANM micro-segmentation: parse filtered policy and DanmEp sets into executable network isolation rules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	k8s.io/apimachinery v0.19.0-alpha.1.0.20200331211856-243f646b5bc8
 	k8s.io/client-go v0.0.0-20200404181738-fe32aa3b9449
 	k8s.io/code-generator v0.18.2
+	k8s.io/kubernetes v1.14.10
 )

--- a/pkg/netruleset/netruleset.go
+++ b/pkg/netruleset/netruleset.go
@@ -1,10 +1,87 @@
 package netruleset
 
 import (
+  "log"
+  "github.com/nokia/danm/pkg/ipam"
   polv1 "github.com/nokia/danm-utils/crd/api/netpol/v1"
   "github.com/nokia/danm-utils/types/poltypes"
+  metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+  "k8s.io/kubernetes/pkg/apis/networking"
 )
 
-func NewNetRuleSet(polSet []polv1.DanmNetworkPolicy, depSet *poltypes.DanmEpBuckets, namespace string) *poltypes.NetRuleSet {
-  return &poltypes.NetRuleSet{}
+const (
+  IngressV4ChainName = "DANM_INGRESS_V4"
+  IngressV6ChainName = "DANM_INGRESS_V6"
+  EgressV4ChainName = "DANM_EGRESS_V4"
+  EgressV6ChainName = "DANM_EGRESS_V6"
+)
+
+type RuleParser func(address string, ports []networking.NetworkPolicyPort) []poltypes.NetRule
+
+func NewNetRuleSet(polSet []polv1.DanmNetworkPolicy, depSet poltypes.DanmEpBuckets, namespace string) *poltypes.NetRuleSet {
+  ruleSet := poltypes.NetRuleSet{}
+  ruleSet.IngressV4Chain.Name = IngressV4ChainName
+  ruleSet.IngressV6Chain.Name = IngressV6ChainName
+  ruleSet.EgressV4Chain.Name = EgressV4ChainName
+  ruleSet.EgressV6Chain.Name = EgressV6ChainName
+  for _, policy := range polSet {
+    ruleSet.IngressV4Chain.Rules, ruleSet.IngressV6Chain.Rules = parseAndAppendPolicyRules(depSet, policy.Spec.Ingress.From, policy.Spec.Ingress.Ports, newIngressNetRules)
+    ruleSet.EgressV4Chain.Rules, ruleSet.EgressV6Chain.Rules = parseAndAppendPolicyRules(depSet, policy.Spec.Egress.To, policy.Spec.Egress.Ports, newEgressNetRules)
+  }
+  return &ruleSet
+}
+
+func parseAndAppendPolicyRules(depSet poltypes.DanmEpBuckets, peers []polv1.NetworkPolicyPeer, ports []networking.NetworkPolicyPort, parserFunc RuleParser) ([]poltypes.NetRule,[]poltypes.NetRule) {
+  v4Rules := make([]poltypes.NetRule, 0)
+  v6Rules := make([]poltypes.NetRule, 0)
+  for _, peer := range peers {
+    depCache := make(poltypes.UidCache, 0)
+    selectors, err := metav1.LabelSelectorAsMap(&peer.PodSelector)
+    if err != nil {
+      log.Println("WARNING: PodSelector parsing failed with error:" + err.Error() + ", ignoring related peers!")
+      continue
+    }
+    for key, value := range selectors {
+      for _, dep := range depSet[key+value+poltypes.CustomBucketPostfix] {
+        if _, ok := depCache[dep.ObjectMeta.UID]; !ok {
+          depCache[dep.ObjectMeta.UID] = true
+          if dep.Spec.Iface.Address != "" && dep.Spec.Iface.Address != ipam.NoneAllocType {
+            v4Rules = append(v4Rules, parserFunc(dep.Spec.Iface.Address, ports)...)
+          }
+          if dep.Spec.Iface.AddressIPv6 != "" && dep.Spec.Iface.AddressIPv6 != ipam.NoneAllocType {
+            v6Rules = append(v6Rules, parserFunc(dep.Spec.Iface.AddressIPv6, ports)...)
+          }
+        }
+      }
+    }
+  }
+  return v4Rules, v6Rules
+}
+
+func newIngressNetRules(address string, ports []networking.NetworkPolicyPort) []poltypes.NetRule {
+  ingressRules := make([]poltypes.NetRule, 0)
+  if len(ports) == 0 {
+    universalRule := poltypes.NetRule{SourceIp: address}
+    ingressRules = append(ingressRules, universalRule)
+    return ingressRules
+  }
+  for _, port := range ports {
+    ingressRule := poltypes.NetRule{SourceIp: address, SourcePort: port.Port.StrVal, Protocol: string(*port.Protocol)}
+    ingressRules = append(ingressRules, ingressRule)
+  }
+  return ingressRules
+}
+
+func newEgressNetRules(address string, ports []networking.NetworkPolicyPort) []poltypes.NetRule {
+  egressRules := make([]poltypes.NetRule, 0)
+  if len(ports) == 0 {
+    universalRule := poltypes.NetRule{DestIp: address}
+    egressRules = append(egressRules, universalRule)
+    return egressRules
+  }
+  for _, port := range ports {
+    egressRule := poltypes.NetRule{DestIp: address, DestPort: port.Port.StrVal, Protocol: string(*port.Protocol)}
+    egressRules = append(egressRules, egressRule)
+  }
+  return egressRules
 }

--- a/pkg/polctrl/polctrl.go
+++ b/pkg/polctrl/polctrl.go
@@ -132,7 +132,7 @@ func (netpolCtrl *NetPolControl) AddPod(pod interface{}) {
     return
   }
   depSet := depset.NewDanmEpSet(netpolCtrl.DanmClient, podObj.ObjectMeta.Namespace)
-  netRuleSet := netruleset.NewNetRuleSet(applicablePols, depSet.DanmEps, podObj.ObjectMeta.Namespace)
+  netRuleSet := netruleset.NewNetRuleSet(applicablePols, *depSet.DanmEps, podObj.ObjectMeta.Namespace)
   //TODOD: make this configurable once we have multiple executors to choose from
   ruleProvisioner := iptables.NewIptablesProvisioner()
   err := ruleProvisioner.AddRulesToPod(netRuleSet, podObj)

--- a/types/poltypes/poltypes.go
+++ b/types/poltypes/poltypes.go
@@ -1,7 +1,6 @@
 package poltypes
 
 import (
-  "net"
   danmv1 "github.com/nokia/danm/crd/apis/danm/v1"
   corev1 "k8s.io/api/core/v1"
   "k8s.io/apimachinery/pkg/types"
@@ -33,9 +32,9 @@ type NetRuleChain struct {
 }
 
 type NetRule struct {
-  SourceIp   *net.IPNet
-  SourcePort int
-  DestIp     *net.IPNet
-  DestPort   int
+  SourceIp   string
+  SourcePort string
+  DestIp     string
+  DestPort   string
   Protocol   string
 }


### PR DESCRIPTION
Implementation done for both Ingress, and Engress, V4 and V6.
Currently only PodSelector is taken into account from the NetworkPolicyPeer definition.
This concise set of executable isolation rules will be passed to an executor in the next step, alongside a network namespace to provision them into.