### PR TITLE
Fix typo: bull->null

### DIFF
--- a/build_cleaner.sh
+++ b/build_cleaner.sh
@@ -4,7 +4,7 @@ echo 'Building DANM utils builder container'
 docker build --pull --target=builder --tag=utils-builder:1.0 -f scm/build/Dockerfile .
 
 echo 'Building DANM cleaner image and binary'
-docker build --pull --target=cleaner --tag="danm-utils:${LATEST_TAG:-$(git describe --tags --dirty 2>/dev/bull)}" -f scm/build/Dockerfile .
+docker build --pull --target=cleaner --tag="danm-utils:${LATEST_TAG:-$(git describe --tags --dirty 2>/dev/null)}" -f scm/build/Dockerfile .
 docker run --rm --net=host --name=utils-builder -v ${GOPATH}/bin:/go/bin -v ${PWD}:/go/src/github.com/nokia/danm-utils utils-builder:1.0
 
 echo 'Cleaning up DANM utils builder container'


### PR DESCRIPTION
Since `/dev/bull` exists on a very tiny number of machines, while
`/dev/null` is as near to a POSIX standard as they come, use `/dev/null`
instead of `/dev/bull`.

Fixes #16

Signed-off-by: Seán C McCord <ulexus@gmail.com>