### PR TITLE
Cleaner to call static CNI specific API to release IPs (cont.)

### DIFF
--- a/pkg/danmep/danm.go
+++ b/pkg/danmep/danm.go
@@ -1,0 +1,15 @@
+package danmep
+
+import (
+    danmipam "github.com/nokia/danm/pkg/ipam"
+)
+
+type danmReleaseIPServiceImpl releaseIPServiceImplBase
+
+func (h *danmReleaseIPServiceImpl) IsIPAllocatedByMe(ip string) bool {
+    return danmipam.WasIpAllocatedByDanm(ip, h.dnet.Spec.Options.Cidr)
+}
+
+func (h *danmReleaseIPServiceImpl) ReleaseIP(ip string) error {
+    return danmipam.Free(h.danmClient, *h.dnet, ip)
+}

--- a/pkg/danmep/interface.go
+++ b/pkg/danmep/interface.go
@@ -1,77 +1,61 @@
 package danmep
 
 import (
+    "context"
     "fmt"
 
     danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
     danmclientset "github.com/nokia/danm/crd/client/clientset/versioned"
-    "github.com/nokia/danm/pkg/danmep"
-    "github.com/nokia/danm/pkg/ipam"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // GetSupportedReleaseIPHandlers gets all supported static CNI implementation that cleaner can use
 // when deleting dangling DanmEps
-func GetSupportedReleaseIPHandlers() []*ReleaseIPService {
-    return []*ReleaseIPService{
-        NewReleaseIPService(&calicoReleaseIPServiceImpl{}),
+func GetSupportedReleaseIPHandlers(danmClient danmclientset.Interface, dnet *danmtypes.DanmNet, ep *danmtypes.DanmEp) []interface{} {
+    return []interface{}{
+        &danmReleaseIPServiceImpl{danmClient, dnet, ep},
+        &calicoReleaseIPServiceImpl{danmClient, dnet, ep},
     }
 }
 
 // ReleaseIPInterface need to be implemented by every static CNI IPAM release plugin
 // that want to invoked when Cleaner is cleaning up dangling DanmEps
 type ReleaseIPInterface interface {
-    ReleaseIP(dnet *danmtypes.DanmNet, ep *danmtypes.DanmEp, ip string) error
-    IsIPAllocatedByMe(dnet *danmtypes.DanmNet, ep *danmtypes.DanmEp, ip string) bool
+    ReleaseIP(ip string) error
+    IsIPAllocatedByMe(ip string) bool
 }
 
-type ReleaseIPService struct {
-    handler ReleaseIPInterface
+type releaseIPServiceImplBase struct {
+    danmClient danmclientset.Interface
+    dnet *danmtypes.DanmNet
+    ep *danmtypes.DanmEp
 }
 
-// NewReleaseIPService constructor encapsulates different ReleaseIPInterface implementations under a generic API
-func NewReleaseIPService(handler ReleaseIPInterface) *ReleaseIPService {
-    return &ReleaseIPService{handler}
-}
-
-// IsIPAllocatedByMe invokes embedded implementation specific IsIPAllocatedByMe function
-func (d ReleaseIPService) IsIPAllocatedByMe(dnet *danmtypes.DanmNet, ep *danmtypes.DanmEp, ip string) bool {
-    return d.handler.IsIPAllocatedByMe(dnet, ep, ip)
-}
-
-// ReleaseIP invokes embedded implementation specific DeleteDanmEp function
-func (d ReleaseIPService) ReleaseIP(dnet *danmtypes.DanmNet, ep *danmtypes.DanmEp, ip string) error {
-    return d.handler.ReleaseIP( dnet, ep, ip)
-}
-
-// SelectAppropriateServiceImplementation looks up and returns the
+// SelectReleaseIpServiceImplementation looks up and returns the
 // first suitable ReleaseIP service implementation for given IP address
 // returns nil when no suitable implementation found
-func SelectAppropriateServiceImplementation(dnet *danmtypes.DanmNet, ep *danmtypes.DanmEp, ip string) *ReleaseIPService {
-    for _, handler := range GetSupportedReleaseIPHandlers() {
-        if handler.IsIPAllocatedByMe(dnet, ep, ip) {
-            return handler
+func SelectReleaseIpServiceImplementation(danmClient danmclientset.Interface, dnet *danmtypes.DanmNet, ep *danmtypes.DanmEp, ip string) ReleaseIPInterface {
+    for _, impl := range GetSupportedReleaseIPHandlers(danmClient, dnet, ep) {
+        if service, ok := impl.(ReleaseIPInterface); ok && service.IsIPAllocatedByMe(ip) {
+            return service
         }
     }
     return nil
 }
 
-// DeleteDanmEp selects an ReleaseIPService implementation for the allocated IPv4 and IPv6 IP addresses
-// in a given DanmEp and invokes them separately trying ot free up allocated IPs, after successfully freeing up
-// the IPs, it deletes the DanmEp or returns error if unable to free any of the IPs or unable todelete DanmEp
+// DeleteDanmEp selects an ReleaseIPService implementation for allocated IPv4 and IPv6 IP addresses in a
+// given DanmEp and invokes them separately trying ot free up allocated IPs, after successfully freeing up
+// all IPs, it deletes the DanmEp, returns error if unable to free any of the IPs or unable to delete DanmEp
 func DeleteDanmEp(danmClient danmclientset.Interface, ep *danmtypes.DanmEp, dnet *danmtypes.DanmNet) error {
-    if ! ipam.WasIpAllocatedByDanm(ep.Spec.Iface.Address, dnet.Spec.Options.Cidr) {
-        if service := SelectAppropriateServiceImplementation(dnet, ep, ep.Spec.Iface.Address); service != nil {
-            if err := service.ReleaseIP(dnet, ep, ep.Spec.Iface.Address); err != nil {
-                return fmt.Errorf("unable to release ipv4 IP because: %s", err)
-            }
+    if service := SelectReleaseIpServiceImplementation(danmClient, dnet, ep, ep.Spec.Iface.Address); service != nil {
+        if err := service.ReleaseIP(ep.Spec.Iface.Address); err != nil {
+            return fmt.Errorf("unable to release ipv4 IP because: %s", err)
         }
     }
-    if ! ipam.WasIpAllocatedByDanm(ep.Spec.Iface.AddressIPv6, dnet.Spec.Options.Pool6.Cidr) {
-        if service := SelectAppropriateServiceImplementation(dnet, ep, ep.Spec.Iface.AddressIPv6); service != nil {
-            if err := service.ReleaseIP(dnet, ep, ep.Spec.Iface.AddressIPv6); err != nil {
-                return fmt.Errorf("unable to release ipv6 IP because: %s", err)
-            }
+    if service := SelectReleaseIpServiceImplementation(danmClient, dnet, ep, ep.Spec.Iface.AddressIPv6); service != nil {
+        if err := service.ReleaseIP(ep.Spec.Iface.AddressIPv6); err != nil {
+            return fmt.Errorf("unable to release ipv6 IP because: %s", err)
         }
     }
-    return danmep.DeleteDanmEp(danmClient, ep, dnet)
+    return danmClient.DanmV1().DanmEps(ep.ObjectMeta.Namespace).Delete(context.TODO(), ep.ObjectMeta.Name, metav1.DeleteOptions{})
 }


### PR DESCRIPTION
Left out from nokia/danm-utils#26

Refactor interface encapsulation, using golang type assertion gives leaner code
Extract danm IPAM release into ReleaseIP API implementation
Add skipping empty IP for calico ReleaseIP

Cleaner cannot use `danmep.DeleteDanmEp` function when releasing Danm IPAM managed IPs, because it handles DanmEp IPv4 and IPv6 addresses together. Instead using `ipam.Free` directly enables handling DanmEp IPs separately.
