### PR TITLE
Cleaner is deleting danmEP without freeing its IPv6 IP

### DIFF
--- a/pkg/danmep/calico.go
+++ b/pkg/danmep/calico.go
@@ -14,6 +14,7 @@ type calicoReleaseIPServiceImpl releaseIPServiceImplBase
 func (h *calicoReleaseIPServiceImpl) IsIPAllocatedByMe(ip string) bool {
     return ip != danmipam.NoneAllocType && ip != "" &&
         ! danmipam.WasIpAllocatedByDanm(ip, h.dnet.Spec.Options.Cidr) &&
+        ! danmipam.WasIpAllocatedByDanm(ip, h.dnet.Spec.Options.Pool6.Cidr) &&
         h.ep.Spec.NetworkType == "calico"
 }
 

--- a/pkg/danmep/danm.go
+++ b/pkg/danmep/danm.go
@@ -7,7 +7,8 @@ import (
 type danmReleaseIPServiceImpl releaseIPServiceImplBase
 
 func (h *danmReleaseIPServiceImpl) IsIPAllocatedByMe(ip string) bool {
-    return danmipam.WasIpAllocatedByDanm(ip, h.dnet.Spec.Options.Cidr)
+    return danmipam.WasIpAllocatedByDanm(ip, h.dnet.Spec.Options.Cidr) ||
+        danmipam.WasIpAllocatedByDanm(ip, h.dnet.Spec.Options.Pool6.Cidr)
 }
 
 func (h *danmReleaseIPServiceImpl) ReleaseIP(ip string) error {

--- a/pkg/danmep/interface.go
+++ b/pkg/danmep/interface.go
@@ -51,11 +51,15 @@ func DeleteDanmEp(danmClient danmclientset.Interface, ep *danmtypes.DanmEp, dnet
         if err := service.ReleaseIP(ep.Spec.Iface.Address); err != nil {
             return fmt.Errorf("unable to release ipv4 IP because: %s", err)
         }
+    } else {
+      return fmt.Errorf("unable to release ipv4 IP because: no releaseIP Service selected")
     }
     if service := SelectReleaseIpServiceImplementation(danmClient, dnet, ep, ep.Spec.Iface.AddressIPv6); service != nil {
         if err := service.ReleaseIP(ep.Spec.Iface.AddressIPv6); err != nil {
             return fmt.Errorf("unable to release ipv6 IP because: %s", err)
         }
+    } else {
+        return fmt.Errorf("unable to release ipv6 IP because: no releaseIP Service selected")
     }
     return danmClient.DanmV1().DanmEps(ep.ObjectMeta.Namespace).Delete(context.TODO(), ep.ObjectMeta.Name, metav1.DeleteOptions{})
 }


### PR DESCRIPTION
Fixes nokia/danm-utils#28

Add missing condition when IP is of type IPv6 causing v6 IPs stay allocated after deleting their DanmEp object.